### PR TITLE
Implement shorthand functions to do simple validations

### DIFF
--- a/src/shorthand.php
+++ b/src/shorthand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Substantiation\Shorthand;
 
+use Optional\Either;
+
 use Substantiation\Validator;
 use Substantiation\ValidatorParser;
 use Substantiation\CallableValidator;
@@ -44,4 +46,12 @@ function optional($key, $value): OptionalPair {
  */
 function validator($pattern): Validator {
     return (new ValidatorParser())->visit($pattern);
+}
+
+function validate($pattern, $value): Either {
+    return validator($pattern)->validate($value);
+}
+
+function valid($pattern, $value): bool {
+    return validate($pattern, $value)->hasValue();
 }

--- a/tests/OneStepValidationTest.php
+++ b/tests/OneStepValidationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Substantiation\Tests;
+
+use function Substantiation\Shorthand\valid;
+use function Substantiation\Shorthand\validate;
+
+class OneStepValidationTest extends TestCase {
+    public function testPredicateValidation() {
+        $this->assertTrue(valid([], []));
+        $this->assertTrue(valid('is_int', 42));
+        $this->assertFalse(valid('is_string', 42));
+    }
+
+    public function testImmediateValidation() {
+        $this->assertSome(validate([], []));
+        $this->assertSome(validate('is_int', 42));
+        $this->assertNone(validate('is_string', 42));
+    }
+}


### PR DESCRIPTION
When there's only one value to be validated, the standard interface is
more complex than necessary. This provides two functions to
immediately validate a value against a pattern. One returns the
resulting `Either`, while the other returns a boolean indicating only
whether the value was valid.