### PR TITLE
Bugfix: Use triple equals, not double equals

### DIFF
--- a/src/PatternVisitor.php
+++ b/src/PatternVisitor.php
@@ -22,7 +22,7 @@ abstract class PatternVisitor {
         }
 
         if (is_array($p)) {
-            if (array_keys($p) == [0]) {
+            if (array_keys($p) === [0]) {
                 return $this->array($p[0]);
             } else {
                 return $this->mapPairs($p);

--- a/tests/UltrashortInterfaceTest.php
+++ b/tests/UltrashortInterfaceTest.php
@@ -22,6 +22,7 @@ class UltrashortInterfaceTest extends TestCase {
         $this->assertInvalid(validator([fail()]), [1]);
         $this->assertInvalid(validator([fail()]), 42);
         $this->assertValid(validator([pass()]), [1]);
+        $this->assertInvalid(validator(['a' => call('is_int')]), 0);
 
         $key = $this->faker->numberBetween();
         $value = $this->faker->word;


### PR DESCRIPTION
Using double equals meant that the list of array keys was testing
equal even though it wasn't. I think this was because it had a single
item which wasn't numeric, so it would become `0` when cast to a
number. As a result of the mistaken conversion, the indexing on the
next line was failing, because that key did not actually exist.