### PR TITLE
Improve pattern error message

### DIFF
--- a/src/PatternVisitor.php
+++ b/src/PatternVisitor.php
@@ -34,7 +34,8 @@ abstract class PatternVisitor {
             return $this->target($p);
         }
 
-        throw new \RuntimeException("Invalid pattern");
+        $pat = var_export($p, true);
+        throw new \RuntimeException("Invalid pattern: `$pat`");
     }
 
     private function mapPairs(array $p) {


### PR DESCRIPTION
We want to give the user a clear error message when a pattern is
incorrect. This allows them to more easily understand what part of the
pattern is wrong.